### PR TITLE
Link to persistent DOI, instead of raw URL

### DIFF
--- a/src/figshare/Wikipedia Detox Data - Getting Started.ipynb
+++ b/src/figshare/Wikipedia Detox Data - Getting Started.ipynb
@@ -12,7 +12,7 @@
    "metadata": {},
    "source": [
     "This notebook gives an introduction to working with the [Wikipedia\n",
-    "Detox data release](https://figshare.com/articles/Wikipedia_Detox_Data/4054689). The release includes 100k labeled discussion comments from English Wikipedia. Each comment was labeled by multiple annotators via CrowdFlower on whether it contains 1) a personal attack and 2) conveys aggressive tone. In addition to the crowd-annotated data, we provide a corpus of comments from 2015 that were scored by a machine learning model trained on the crowd-annotated data. See our [wiki](https://meta.wikimedia.org/wiki/Research:Detox/Data_Release) for documentation of the schema of each file and our [research paper](https://arxiv.org/abs/1610.08914) for documentation on the data collection and modeling methodology.\n",
+    "Detox data release](https://doi.org/10.6084/m9.figshare.4054689). The release includes 100k labeled discussion comments from English Wikipedia. Each comment was labeled by multiple annotators via CrowdFlower on whether it contains 1) a personal attack and 2) conveys aggressive tone. In addition to the crowd-annotated data, we provide a corpus of comments from 2015 that were scored by a machine learning model trained on the crowd-annotated data. See our [wiki](https://meta.wikimedia.org/wiki/Research:Detox/Data_Release) for documentation of the schema of each file and our [research paper](https://arxiv.org/abs/1610.08914) for documentation on the data collection and modeling methodology.\n",
     "\n",
     "In this notebook we show how to build a simple classifier for detecting personal attacks using crowd-annotated data and give an example of how the corpus of model-annotated data can be used for analysis."
    ]


### PR DESCRIPTION
I fixed the link to point to the persistent DOI of the dataset.